### PR TITLE
Rename the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,50 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/jonaskello/eslint-plugin-ts-immutable/compare/v0.3.0...HEAD)
+## [Unreleased](https://github.com/jonaskello/eslint-plugin-functional/compare/v0.3.0...HEAD)
 
-## [v0.3.0](https://github.com/jonaskello/eslint-plugin-ts-immutable/compare/v0.2.1...v0.3.0)
+## [v0.3.0](https://github.com/jonaskello/eslint-plugin-functional/compare/v0.2.1...v0.3.0)
 
 ### Merged
 
-- ReadonlySet and ReadonlyMap [`#30`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/30)
-- prefer-readonly-types [`#29`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/29)
-- no-return-void [`#28`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/28)
-- functional-parameters [`#27`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/27)
-- feat(readonly-keyword) Add support for parameter properties [`#26`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/26)
-- no-conditional-statement [`#23`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/23)
-- chore: Remove no-delete rule. [`#21`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/21)
-- new rule: immutable-data [`#22`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/22)
+- ReadonlySet and ReadonlyMap [`#30`](https://github.com/jonaskello/eslint-plugin-functional/pull/30)
+- prefer-readonly-types [`#29`](https://github.com/jonaskello/eslint-plugin-functional/pull/29)
+- no-return-void [`#28`](https://github.com/jonaskello/eslint-plugin-functional/pull/28)
+- functional-parameters [`#27`](https://github.com/jonaskello/eslint-plugin-functional/pull/27)
+- feat(readonly-keyword) Add support for parameter properties [`#26`](https://github.com/jonaskello/eslint-plugin-functional/pull/26)
+- no-conditional-statement [`#23`](https://github.com/jonaskello/eslint-plugin-functional/pull/23)
+- chore: Remove no-delete rule. [`#21`](https://github.com/jonaskello/eslint-plugin-functional/pull/21)
+- new rule: immutable-data [`#22`](https://github.com/jonaskello/eslint-plugin-functional/pull/22)
 
 ### Fixed
 
-- feat(immutable-data): Prevent object mutation methods. [`#16`](https://github.com/jonaskello/eslint-plugin-ts-immutable/issues/16)
+- feat(immutable-data): Prevent object mutation methods. [`#16`](https://github.com/jonaskello/eslint-plugin-functional/issues/16)
 
-## [v0.2.1](https://github.com/jonaskello/eslint-plugin-ts-immutable/compare/v0.2.0...v0.2.1) - 2019-07-12
+## [v0.2.1](https://github.com/jonaskello/eslint-plugin-functional/compare/v0.2.0...v0.2.1) - 2019-07-12
 
 ### Merged
 
-- Remove no-let fixer [`#14`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/14)
+- Remove no-let fixer [`#14`](https://github.com/jonaskello/eslint-plugin-functional/pull/14)
 
 ### Fixed
 
 - TypeScript is no longer imported unless it is available.
 
-## [v0.2.0](https://github.com/jonaskello/eslint-plugin-ts-immutable/compare/v0.1.0...v0.2.0) - 2019-07-12
+## [v0.2.0](https://github.com/jonaskello/eslint-plugin-functional/compare/v0.1.0...v0.2.0) - 2019-07-12
 
 ### Merged
 
-- docs: Update supported rules. [`#8`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/8)
-- Make the code more functional [`#9`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/9)
-- Added ignoreAccessorPattern, ignorePattern now uses Regex matching [`#7`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/7)
-- Ignore option fix [`#6`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/6)
-- Consistent file casing [`#5`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/5)
-- Port docs for each rule [`#3`](https://github.com/jonaskello/eslint-plugin-ts-immutable/pull/3)
+- docs: Update supported rules. [`#8`](https://github.com/jonaskello/eslint-plugin-functional/pull/8)
+- Make the code more functional [`#9`](https://github.com/jonaskello/eslint-plugin-functional/pull/9)
+- Added ignoreAccessorPattern, ignorePattern now uses Regex matching [`#7`](https://github.com/jonaskello/eslint-plugin-functional/pull/7)
+- Ignore option fix [`#6`](https://github.com/jonaskello/eslint-plugin-functional/pull/6)
+- Consistent file casing [`#5`](https://github.com/jonaskello/eslint-plugin-functional/pull/5)
+- Port docs for each rule [`#3`](https://github.com/jonaskello/eslint-plugin-functional/pull/3)
 
 ### Fixed
 
-- feat(ignore-option): Add ignoreAccessorPattern option to deal with accessors and switch ignorePatter [`#4`](https://github.com/jonaskello/eslint-plugin-ts-immutable/issues/4)
+- feat(ignore-option): Add ignoreAccessorPattern option to deal with accessors and switch ignorePatter [`#4`](https://github.com/jonaskello/eslint-plugin-functional/issues/4)
 
-## [v0.1.0](https://github.com/jonaskello/eslint-plugin-ts-immutable/releases/tag/v0.1.0) - 2019-07-01
+## [v0.1.0](https://github.com/jonaskello/eslint-plugin-functional/releases/tag/v0.1.0) - 2019-07-01
 
 This is the first release and everything is experimental at this point.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eslint-plugin-ts-immutable
+# eslint-plugin-functional
 
 [![npm version][version-image]][version-url]
 [![travis build][travis-image]][travis-url]
@@ -6,9 +6,23 @@
 [![code style: prettier][prettier-image]][prettier-url]
 [![MIT license][license-image]][license-url]
 
-[ESLint](https://eslint.org/) rules to disable mutation in JavaScript and TypeScript.
+[ESLint](https://eslint.org/) rules to disable mutation and promote fp in JavaScript and TypeScript.
 
-## Background
+## Introduction
+
+> :wave: If you previously used the rules in [tslint-immutable](https://www.npmjs.com/package/tslint-immutable), this package is the eslint version of those rules. Please see the [migration guide](docs/user-guide/migrating-from-tslint.md) for how to migrate.
+
+This package has a collection of eslint rules to promote functional programming style concepts. Note that you can use this package to enforce only some aspects of functional programming, for example only immutabiltiy. There are also options for the rules that allow you to gradually adopt a functional style. Most rules can be used both for JavaScript and TypeScript, however some rules, for example enforcing the `readonly` keyword, is of course only available for TypeScript.
+
+We've identified the following areas that needs to be linted in order to promote functional style in TypeScript/JavaScript:
+
+- [No mutability](#no-mutability)
+- [No object-orientation](#no-object-orientation)
+- [No statements](#no-statements)
+- [No exceptions](#no-exceptions)
+- [Currying](#currying)
+
+### No mutability
 
 In some applications it is important to not mutate any data, for example when using Redux to store state in a React application. Moreover immutable data structures has a lot of advantages in general so I want to use them everywhere in my applications.
 
@@ -16,20 +30,36 @@ I originally used [immutablejs](https://github.com/facebook/immutable-js/) for t
 
 Then TypeScript 2.0 came along and introduced [readonly](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#read-only-properties-and-index-signatures) options for properties, indexers and arrays. TypeScript 3.0 has continued to add support immutability enforcing syntax. This enables us to use regular object and arrays and have the immutability enforced at compile time instead of run-time. Now the only drawback is that there is nothing enforcing the use of readonly in TypeScript.
 
-This can be solved by using linting rules. So the aim of this project is to leverage the type system in TypeScript to enforce immutability at compile-time while still using regular objects and arrays. Additionally, this project will also aim to support vanilla JavaScript where possible.
+This can be solved by using linting rules. So one aim of this project is to leverage the type system in TypeScript to enforce immutability at compile-time while still using regular objects and arrays. Additionally, this project will also aim to support disabling mutability for vanilla JavaScript where possible.
+
+### No object-orientation
+
+JavaScript is multi-paradigm, allowing both object-oriented and functional programming styles. In order to promote a functional style, the object oriented features of JavaScript needs to be disabled.
+
+### No statements
+
+In functional programming everything is an expression that produces a value. Javascript has a lot of syntax that is just statements that does not produce a value. That syntax has to be disabled to promote a functional style.
+
+### No exceptions
+
+Functional programming style does not use run-time exceptions. Instead expressions produces values to indicate errors.
+
+### Currying
+
+Javascript functions support syntax that is not compatible with curried functions. To enable currying this syntax has to be disabled.
 
 ## Installing
 
 ```sh
-npm install eslint eslint-plugin-ts-immutable --save-dev
+npm install eslint eslint-plugin-functional --save-dev
 ```
 
-**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-ts-immutable` globally.
+**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-functional` globally.
 
 To use this plugin with TypeScript, additionally install [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser).
 
 ```sh
-npm install eslint @typescript-eslint/parser eslint-plugin-ts-immutable --save-dev
+npm install eslint @typescript-eslint/parser eslint-plugin-functional --save-dev
 ```
 
 ## Usage
@@ -176,13 +206,13 @@ yarn version --major
 
 This project started off as a port of [tslint-immutable](https://github.com/jonaskello/tslint-immutable) which was originally inspired by [eslint-plugin-immutable](https://github.com/jhusain/eslint-plugin-immutable).
 
-[version-image]: https://img.shields.io/npm/v/eslint-plugin-ts-immutable.svg?style=flat
-[version-url]: https://www.npmjs.com/package/eslint-plugin-ts-immutable
-[travis-image]: https://travis-ci.com/jonaskello/eslint-plugin-ts-immutable.svg?branch=master&style=flat
-[travis-url]: https://travis-ci.com/jonaskello/eslint-plugin-ts-immutable
-[codecov-image]: https://codecov.io/gh/jonaskello/eslint-plugin-ts-immutable/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/jonaskello/eslint-plugin-ts-immutable
-[license-image]: https://img.shields.io/github/license/jonaskello/eslint-plugin-ts-immutable.svg?style=flat
+[version-image]: https://img.shields.io/npm/v/eslint-plugin-functional.svg?style=flat
+[version-url]: https://www.npmjs.com/package/eslint-plugin-functional
+[travis-image]: https://travis-ci.com/jonaskello/eslint-plugin-functional.svg?branch=master&style=flat
+[travis-url]: https://travis-ci.com/jonaskello/eslint-plugin-functional
+[codecov-image]: https://codecov.io/gh/jonaskello/eslint-plugin-functional/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/jonaskello/eslint-plugin-functional
+[license-image]: https://img.shields.io/github/license/jonaskello/eslint-plugin-functional.svg?style=flat
 [license-url]: https://opensource.org/licenses/MIT
 [prettier-image]: https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat
 [prettier-url]: https://github.com/prettier/prettier

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ See [@typescript-eslint/parser's README.md](https://github.com/typescript-eslint
 | [`no-let`](./docs/rules/no-let.md)                               | Disallow mutable variables                                                 |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
 | [`immutable-data`](./docs/rules/immutable-data.md)               | Disallow mutating objects and arrays                                       |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |   :blue_heart:    |
 | [`no-method-signature`](./docs/rules/no-method-signature.md)     | Enforce property signatures with readonly modifiers over method signatures |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
-| <td colspan=2> No object-orientation                             |
-| [`no-method-signature`](./docs/rules/no-method-signature.md)     | Enforce property signatures with readonly modifiers over method signatures |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
 
 ### No object-orientation
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ See [@typescript-eslint/parser's README.md](https://github.com/typescript-eslint
 | [`no-let`](./docs/rules/no-let.md)                               | Disallow mutable variables                                                 |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
 | [`immutable-data`](./docs/rules/immutable-data.md)               | Disallow mutating objects and arrays                                       |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |   :blue_heart:    |
 | [`no-method-signature`](./docs/rules/no-method-signature.md)     | Enforce property signatures with readonly modifiers over method signatures |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
+| No object-orientation                                            |
+| [`no-method-signature`](./docs/rules/no-method-signature.md)     | Enforce property signatures with readonly modifiers over method signatures |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
 
 ### No object-orientation
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ See [@typescript-eslint/parser's README.md](https://github.com/typescript-eslint
 | [`no-let`](./docs/rules/no-let.md)                               | Disallow mutable variables                                                 |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
 | [`immutable-data`](./docs/rules/immutable-data.md)               | Disallow mutating objects and arrays                                       |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |   :blue_heart:    |
 | [`no-method-signature`](./docs/rules/no-method-signature.md)     | Enforce property signatures with readonly modifiers over method signatures |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
-| No object-orientation                                            |
+| <td colspan=2> No object-orientation                             |
 | [`no-method-signature`](./docs/rules/no-method-signature.md)     | Enforce property signatures with readonly modifiers over method signatures |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
 
 ### No object-orientation

--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ See [@typescript-eslint/parser's README.md](https://github.com/typescript-eslint
 
 ## Supported Rules
 
-In addition to immutable rules this project also contains a few rules for enforcing a functional style of programming. The following rules are available:
-
 **Key**:
 
 |      Symbol       | Meaning                                                                                                                                |
@@ -127,7 +125,7 @@ In addition to immutable rules this project also contains a few rules for enforc
 | :thought_balloon: | Only Avaliable for TypeScript<br><sub><sup>The rule either requires Type Information or only works with TypeScript syntax.</sup></sub> |
 |   :blue_heart:    | Works better with TypeScript<br><sub><sup>Type Information will be used if available making the rule work in more case.</sup></sub>    |
 
-### Immutability rules
+### No mutability
 
 | Name                                                             | Description                                                                | <span title="Recommended">:see_no_evil:</span> | <span title="Functional Lite">:hear_no_evil:</span> | <span title="Functional">:speak_no_evil:</span> | :wrench: |   :blue_heart:    |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------- | :--------------------------------------------: | :-------------------------------------------------: | :---------------------------------------------: | :------: | :---------------: |
@@ -136,21 +134,36 @@ In addition to immutable rules this project also contains a few rules for enforc
 | [`immutable-data`](./docs/rules/immutable-data.md)               | Disallow mutating objects and arrays                                       |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |   :blue_heart:    |
 | [`no-method-signature`](./docs/rules/no-method-signature.md)     | Enforce property signatures with readonly modifiers over method signatures |               :heavy_check_mark:               |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
 
-### Functional style rules
+### No object-orientation
 
-| Name                                                                   | Description                                                                   | <span title="Recommended">:see_no_evil:</span> | <span title="Functional Lite">:hear_no_evil:</span> | <span title="Functional">:speak_no_evil:</span> | :wrench: |   :blue_heart:    |
-| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------- | :--------------------------------------------: | :-------------------------------------------------: | :---------------------------------------------: | :------: | :---------------: |
-| [`no-this`](./docs/rules/no-this.md)                                   | Disallow this access                                                          |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
-| [`no-class`](./docs/rules/no-class.md)                                 | Disallow classes                                                              |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
-| [`no-mixed-interface`](./docs/rules/no-mixed-interface.md)             | Restrict interfaces so that only members of the same kind are allowed in them |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
-| [`no-expression-statement`](./docs/rules/no-expression-statement.md)   | Disallow expressions to cause side-effects                                    |                                                |                                                     |               :heavy_check_mark:                |          |                   |
-| [`no-conditional-statement`](./docs/rules/no-conditional-statement.md) | Disallow conditional statements (if and switch statements)                    |                                                |                                                     |               :heavy_check_mark:                |          |                   |
-| [`no-loop-statement`](./docs/rules/no-loop-statement.md)               | Disallow imperative loops                                                     |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
-| [`no-return-void`](./docs/rules/no-return-void.md)                     | Disallow function that return nothing                                         |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
-| [`functional-parameters`](./docs/rules/functional-parameters.md)       | Functions must have functional parameter                                      |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
-| [`no-throw`](./docs/rules/no-throw.md)                                 | Disallow throwing exceptions                                                  |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
-| [`no-try`](./docs/rules/no-try.md)                                     | Disallow try-catch[-finally] and try-finally patterns                         |                                                |                                                     |               :heavy_check_mark:                |          |                   |
-| [`no-reject`](./docs/rules/no-reject.md)                               | Disallow rejecting Promises                                                   |                                                |                                                     |                                                 |          |                   |
+| Name                                                       | Description                                                                   | <span title="Recommended">:see_no_evil:</span> | <span title="Functional Lite">:hear_no_evil:</span> | <span title="Functional">:speak_no_evil:</span> | :wrench: |   :blue_heart:    |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------- | :--------------------------------------------: | :-------------------------------------------------: | :---------------------------------------------: | :------: | :---------------: |
+| [`no-this`](./docs/rules/no-this.md)                       | Disallow this access                                                          |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
+| [`no-class`](./docs/rules/no-class.md)                     | Disallow classes                                                              |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
+| [`no-mixed-interface`](./docs/rules/no-mixed-interface.md) | Restrict interfaces so that only members of the same kind are allowed in them |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
+
+### No statements
+
+| Name                                                                   | Description                                                | <span title="Recommended">:see_no_evil:</span> | <span title="Functional Lite">:hear_no_evil:</span> | <span title="Functional">:speak_no_evil:</span> | :wrench: |   :blue_heart:    |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------- | :--------------------------------------------: | :-------------------------------------------------: | :---------------------------------------------: | :------: | :---------------: |
+| [`no-expression-statement`](./docs/rules/no-expression-statement.md)   | Disallow expressions to cause side-effects                 |                                                |                                                     |               :heavy_check_mark:                |          |                   |
+| [`no-conditional-statement`](./docs/rules/no-conditional-statement.md) | Disallow conditional statements (if and switch statements) |                                                |                                                     |               :heavy_check_mark:                |          |                   |
+| [`no-loop-statement`](./docs/rules/no-loop-statement.md)               | Disallow imperative loops                                  |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |                   |
+| [`no-return-void`](./docs/rules/no-return-void.md)                     | Disallow function that return nothing                      |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          | :thought_balloon: |
+
+### No exceptions
+
+| Name                                     | Description                                           | <span title="Recommended">:see_no_evil:</span> | <span title="Functional Lite">:hear_no_evil:</span> | <span title="Functional">:speak_no_evil:</span> | :wrench: | :blue_heart: |
+| ---------------------------------------- | ----------------------------------------------------- | :--------------------------------------------: | :-------------------------------------------------: | :---------------------------------------------: | :------: | :----------: |
+| [`no-throw`](./docs/rules/no-throw.md)   | Disallow throwing exceptions                          |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |              |
+| [`no-try`](./docs/rules/no-try.md)       | Disallow try-catch[-finally] and try-finally patterns |                                                |                                                     |               :heavy_check_mark:                |          |              |
+| [`no-reject`](./docs/rules/no-reject.md) | Disallow rejecting Promises                           |                                                |                                                     |                                                 |          |              |
+
+### Currying
+
+| Name                                                             | Description                              | <span title="Recommended">:see_no_evil:</span> | <span title="Functional Lite">:hear_no_evil:</span> | <span title="Functional">:speak_no_evil:</span> | :wrench: | :blue_heart: |
+| ---------------------------------------------------------------- | ---------------------------------------- | :--------------------------------------------: | :-------------------------------------------------: | :---------------------------------------------: | :------: | :----------: |
+| [`functional-parameters`](./docs/rules/functional-parameters.md) | Functions must have functional parameter |                                                |                 :heavy_check_mark:                  |               :heavy_check_mark:                |          |              |
 
 ## Recommended standard rules
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > :wave: If you previously used the rules in [tslint-immutable](https://www.npmjs.com/package/tslint-immutable), this package is the eslint version of those rules. Please see the [migration guide](docs/user-guide/migrating-from-tslint.md) for how to migrate.
 
-This package has a collection of eslint rules to promote functional programming style concepts. Note that you can use this package to enforce only some aspects of functional programming, for example only immutabiltiy. There are also options for the rules that allow you to gradually adopt a functional style. Most rules can be used both for JavaScript and TypeScript, however some rules, for example enforcing the `readonly` keyword, is of course only available for TypeScript.
+This package has a collection of eslint rules to promote functional programming style concepts. Note that you can use this package to enforce only some aspects of functional programming, for example only immutability. There are also options for the rules that allow you to gradually adopt a functional style. Most rules can be used both for JavaScript and TypeScript, however some rules, for example enforcing the `readonly` keyword, is of course only available for TypeScript.
 
 We've identified the following areas that needs to be linted in order to promote functional style in TypeScript/JavaScript:
 

--- a/docs/user-guide/migrating-from-tslint.md
+++ b/docs/user-guide/migrating-from-tslint.md
@@ -1,0 +1,1 @@
+Placeholder for the migration guide, to be fille din before 1.0.0.

--- a/docs/user-guide/migrating-from-tslint.md
+++ b/docs/user-guide/migrating-from-tslint.md
@@ -1,1 +1,1 @@
-Placeholder for the migration guide, to be fille din before 1.0.0.
+Placeholder for the migration guide, to be filled in before 1.0.0.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "eslint-plugin-ts-immutable",
+  "name": "eslint-plugin-functional",
   "version": "0.3.0",
-  "description": "ESLint rules to disable mutation in TypeScript.",
+  "description": "ESLint rules to disable mutation and promote fp in TypeScript.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jonaskello/eslint-plugin-ts-immutable"
+    "url": "git+https://github.com/jonaskello/eslint-plugin-functional"
   },
   "keywords": [
     "eslint",
@@ -26,9 +26,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jonaskello/eslint-plugin-ts-immutable/issues"
+    "url": "https://github.com/jonaskello/eslint-plugin-functional/issues"
   },
-  "homepage": "https://github.com/jonaskello/eslint-plugin-ts-immutable#readme",
+  "homepage": "https://github.com/jonaskello/eslint-plugin-functional#readme",
   "files": [
     "/lib",
     "package.json",
@@ -91,7 +91,7 @@
     "compile-tests": "tsc -p tsconfig.tests.json",
     "build-tests": "rimraf build && yarn compile-tests",
     "build": "rimraf lib && yarn compile",
-    "prelint": "yarn build && yarn link && yarn link 'eslint-plugin-ts-immutable'",
+    "prelint": "yarn build && yarn link && yarn link 'eslint-plugin-functional'",
     "lint": "eslint './{src,tests}/**/*.ts' --ext .ts",
     "test": "jest --testPathIgnorePatterns _work.test",
     "test-work": "jest tests/rules/_work.test.ts",

--- a/src/util/rule.ts
+++ b/src/util/rule.ts
@@ -52,7 +52,7 @@ export function createRule<
 ): Rule.RuleModule {
   return ESLintUtils.RuleCreator(
     name =>
-      `https://github.com/jonaskello/eslint-plugin-ts-immutable/blob/v${version}/docs/rules/${name}.md`
+      `https://github.com/jonaskello/eslint-plugin-functional/blob/v${version}/docs/rules/${name}.md`
   )({
     name,
     meta,


### PR DESCRIPTION
Fixes #17.

This PR renames the package to eslint-plugin-functional and updates the readme to reflect that there are more rules than immutability.

Also adds a placeholder for #33.